### PR TITLE
Increased plugin personalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ See `config-sample.json` for an example config. This plugin can also be configur
 | `lat`      | Latitude of the location the sun position should be calculated for   |
 | `long`     | Longitude of the location the sun position should be calculated for  |
 | `apikey`     | Your [OpenWeather API key](https://openweathermap.org/api), optional  |
+| `sun` | OpenWeather API minimum sun threshold |
+| `overcast` | OpenWeather API maximum overcast threshold |
 | `sensors`  | Array of objects containing configuration for the sensors, see below |
 | `debugLog` | Debug log output, optional, default: false                 |
 
@@ -36,6 +38,8 @@ Define contact sensors for one or more sections of the sky, e.g. for windows loo
 | `name`           | Display name of the sensor                                                                                |
 | `lowerThreshold` | Left side of sky section within which the sensor should activate |
 | `upperThreshold` | Right side of sky section within which the sensor should activate |
+| `lowerAltitudeThreshold` | Lower Altitude Threshold |
+| `upperAltitudeThreshold` | Upper Altitude Threshold |
 
 **Thresholds example**: If you want the sensor to turn on when the sun is between 0° and 90° azimuth, set the lower threshold to 0 and the upper threshold to 90. See the example configuration file for a basic set-up (north, east, south, west).
 

--- a/base/accessory.js
+++ b/base/accessory.js
@@ -80,7 +80,7 @@ class SunlightAccessory {
 
   updateState() {
     const { config, platformConfig, log } = this;
-    const { lat, long, apikey } = platformConfig;
+    const { lat, long, apikey, sun, overcast } = platformConfig;
     const { lowerThreshold, upperThreshold } = config;
     const threshold = [lowerThreshold, upperThreshold];
 
@@ -128,7 +128,7 @@ class SunlightAccessory {
       let sunState = this.returnSunFromCache();
       let cloudState = this.returnCloudinessFromCache();
       if (platformConfig.debugLog) log(`Sun state: ${sunState}%, Cloud state: ${cloudState}%`);
-      newState = sunState > 10 && sunState <90 && cloudState <= 25;
+      newState = sunState > sun && cloudState <= overcast;
     }
 
     return newState;

--- a/base/accessory.js
+++ b/base/accessory.js
@@ -32,13 +32,13 @@ class SunlightAccessory {
 
   initializeAccessory() {
     const { config } = this;
-    const { lowerThreshold, upperThreshold } = config;
+    const { lowerThreshold, upperThreshold, lowerAltitudeThreshold, upperAltitudeThreshold } = config;
     const uuid = UUIDGen.generate(config.name);
     const accessory = new Accessory(config.name, uuid);
     // Add Device Information
     accessory.getService(Service.AccessoryInformation)
       .setCharacteristic(Characteristic.Manufacturer, 'Krillle')
-      .setCharacteristic(Characteristic.Model, 'Azimuth ' + lowerThreshold + '-' + upperThreshold)
+      .setCharacteristic(Characteristic.Model, 'Azimuth ' + lowerThreshold + '-' + upperThreshold + ' Altitude ' + lowerAltitudeThreshold + '-' + upperAltitudeThreshold)
       .setCharacteristic(Characteristic.SerialNumber, '---');
 
     const SensorService = accessory.addService(Service.ContactSensor, config.name);
@@ -81,8 +81,9 @@ class SunlightAccessory {
   updateState() {
     const { config, platformConfig, log } = this;
     const { lat, long, apikey, sun, overcast } = platformConfig;
-    const { lowerThreshold, upperThreshold } = config;
+    const { lowerThreshold, upperThreshold, lowerAltitudeThreshold, upperAltitudeThreshold } = config;
     const threshold = [lowerThreshold, upperThreshold];
+    const altitudeThreshold = [lowerAltitudeThreshold, upperAltitudeThreshold];
 
     if (!lat || !long || typeof lat !== 'number' || typeof long !== 'number') {
       log('Error: Lat/Long incorrect. Please refer to the README.');
@@ -91,8 +92,10 @@ class SunlightAccessory {
 
     const sunPos = suncalc.getPosition(Date.now(), lat, long);
     let sunPosDegrees = Math.abs((sunPos.azimuth * 180) / Math.PI + 180);
+    let sunPosAltitude = Math.abs(sunPos.altitude * 90);
 
     if (platformConfig.debugLog) log(`Current azimuth: ${sunPosDegrees}°`);
+    if (platformConfig.debugLog) log(`Current altitude: ${sunPosAltitude}°`);
 
     if (threshold[0] > threshold[1]) {
       const tempThreshold = threshold[1];
@@ -101,7 +104,7 @@ class SunlightAccessory {
     }
 
     let newState;
-    if (sunPosDegrees >= threshold[0] && sunPosDegrees <= threshold[1]) {
+    if (sunPosDegrees >= threshold[0] && sunPosDegrees <= threshold[1] && sunPosAltitude >= altitudeThreshold[0] && sunPosAltitude <= altitudeThreshold[1]) {
       newState = true;
     } else {
       newState = false;

--- a/config.schema.json
+++ b/config.schema.json
@@ -23,6 +23,24 @@
                 "description": "If API key is provided, sunhsine is reported only during daylight times when sky is not overcast",
                 "required": false
             },
+            "sun": {
+                "type": "number",
+                "title": "OpenWeather API minimum sun threshold",
+                "description": "If API key is provided, this value set minimum sun threshold",
+                "required": true,
+                "default": 10,
+                "minimum": 0,
+                "maximum": 100
+            },
+            "overcast": {
+                "type": "number",
+                "title": "OpenWeather API maximum overcast threshold",
+                "description": "If API key is provided, this value set maximum overcast threshold",
+                "required": true,
+                "default": 25,
+                "minimum": 0,
+                "maximum": 100
+            },
             "sensors": {
                 "type": "array",
                 "title": "Sensors",

--- a/config.schema.json
+++ b/config.schema.json
@@ -69,6 +69,24 @@
                             "title": "Upper Threshold",
                             "description": "Right side of sky section within which the sensor should activate",
                             "required": true
+                        },
+                        "lowerAltitudeThreshold": {
+                            "type": "number",
+                            "title": "Lower Altitude Threshold",
+                            "description": "Lower altitude threshold within which the sensor should activate",
+                            "required": true,
+                            "default": 0,
+                            "minimum": 0,
+                            "maximum": 90
+                        },
+                        "upperAltitudeThreshold": {
+                            "type": "number",
+                            "title": "Upper Altitude Threshold",
+                            "description": "Upper altitude threshold within which the sensor should activate",
+                            "required": true,
+                            "default": 90,
+                            "minimum": 0,
+                            "maximum": 90
                         }
                     }
                 }


### PR DESCRIPTION
- Added Sun Altitude control with `lowerAltitudeThreshold` and `upperAltitudeThreshold` vars.
- Now OpenWeather API `sun` and `overcast` threshold can be configured by user.