### PR TITLE
Make "Lower/Upper Altitude Thresholds" configurable per sensor

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-github: mfkrause
-custom: ['https://paypal.me/krause69']

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ See `config-sample.json` for an example config. This plugin can also be configur
 | `lat`      | Latitude of the location the sun position should be calculated for   |
 | `long`     | Longitude of the location the sun position should be calculated for  |
 | `apikey`     | Your [OpenWeather API key](https://openweathermap.org/api), optional  |
+| `maxCloudCoverage` | Cloud coverage threshold in percent (100% is cloudy, 0% is sunny), below which the sensor should be activated. Only available if an OpenWeather API key is defined. |
 | `sensors`  | Array of objects containing configuration for the sensors, see below |
 | `debugLog` | Debug log output, optional, default: false                 |
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Homebridge Sunlight
-[![npm-version](https://badgen.net/npm/v/homebridge-sunlight)](https://www.npmjs.com/package/homebridge-sunlight)
-[![npm-downloads](https://badgen.net/npm/dt/homebridge-sunlight)](https://www.npmjs.com/package/homebridge-sunlight)
+# Homebridge Sun Azimuth
+[![npm-version](https://badgen.net/npm/v/homebridge-sun-azimuth)](https://www.npmjs.com/package/homebridge-sun-azimuth)
+[![npm-downloads](https://badgen.net/npm/dt/homebridge-sun-azimuth)](https://www.npmjs.com/package/homebridge-sun-azimuth)
 
 
 This is a plugin for [homebridge](https://github.com/nfarina/homebridge). It provides contact sensors based on sun position and clouds to automate sun protection. Sensors are opened when the sun is in a defined section of the sky (azimuth) and optionally if an [OpenWeather API key](https://openweathermap.org/api) is provided when the sky is not overcast and sun is above the horizon.
@@ -10,7 +10,7 @@ This is a plugin for [homebridge](https://github.com/nfarina/homebridge). It pro
 Intall via hombridge GUI [homebridge-config-ui-x](https://github.com/oznu/homebridge-config-ui-x) or manually via:
 
 1.  Install homebridge (if not already installed) using: `npm install -g homebridge`
-2.  Install this plugin using: `npm install -g homebridge-sunlight`
+2.  Install this plugin using: `npm install -g homebridge-sun-azimuth`
 3.  Update your configuration file (see below).
 
 # Example Configuration
@@ -43,5 +43,5 @@ Define contact sensors for one or more sections of the sky, e.g. for windows loo
 
 **Thresholds example**: If you want the sensor to turn on when the sun is between 0° and 90° azimuth, set the lower threshold to 0 and the upper threshold to 90. See the example configuration file for a basic set-up (north, east, south, west).
 
-For help or in case of issues please visit the [GitHub repository](https://github.com/Krillle/homebridge-sunlight/issues).    
-This plugin is based on [homebridge-sunsensors](https://github.com/mfkrause/homebridge-sunsensors).
+For help or in case of issues please visit the [GitHub repository](https://github.com/awaescher/homebridge-sun-azimuth/issues).    
+This plugin is based  on [homebridge-sunsensors](https://github.com/mfkrause/homebridge-sunsensors) and [homebridge-sunlight](https://github.com/Krillle/homebridge-sunlight)..

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See `config-sample.json` for an example config. This plugin can also be configur
 | `lat`      | Latitude of the location the sun position should be calculated for   |
 | `long`     | Longitude of the location the sun position should be calculated for  |
 | `apikey`     | Your [OpenWeather API key](https://openweathermap.org/api), optional  |
-| `maxCloudCoverage` | Cloud coverage threshold in percent (100% is cloudy, 0% is sunny), below which the sensor should be activated. Only available if an OpenWeather API key is defined. |
+| `highestAcceptableOvercast` | Overcast threshold in percent, below which the sensor should be activated. 0% is sunny, 25% is slightly cloudy and 100% is cloudy. Only available if an OpenWeather API key is defined. |
 | `sensors`  | Array of objects containing configuration for the sensors, see below |
 | `debugLog` | Debug log output, optional, default: false                 |
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ See `config-sample.json` for an example config. This plugin can also be configur
 | `long`     | Longitude of the location the sun position should be calculated for  |
 | `apikey`     | Your [OpenWeather API key](https://openweathermap.org/api), optional  |
 | `highestAcceptableOvercast` | Overcast threshold in percent, below which the sensor should be activated. 0% is sunny, 25% is slightly cloudy and 100% is cloudy. Only available if an OpenWeather API key is defined. |
+| `weatherUpdateIntervalSeconds` | The smaller the interval, the quicker the response to sun position and overcast updates but the more traffic it'll create. The free tier of the OpenWeather API is limited to 1,000,000 requests per month which is roughly one call every 3 seconds for a whole month. |
 | `sensors`  | Array of objects containing configuration for the sensors, see below |
 | `debugLog` | Debug log output, optional, default: false                 |
 
@@ -37,6 +38,8 @@ Define contact sensors for one or more sections of the sky, e.g. for windows loo
 | `name`           | Display name of the sensor                                                                                |
 | `lowerThreshold` | Left side of sky section within which the sensor should activate |
 | `upperThreshold` | Right side of sky section within which the sensor should activate |
+| `lowerAltitudeThreshold` | Lower altitude threshold for the sun's position above the horizon, above which the sensor should activate. The threshold is measured in degrees, with 0° being on the horizon and 90° being at the zenith. |
+| `upperAltitudeThreshold` | Upper altitude threshold for the sun's position above the horizon, below which the sensor should activate. The threshold is measured in degrees, with 0° being on the horizon and 90° being at the zenith. |
 
 **Thresholds example**: If you want the sensor to turn on when the sun is between 0° and 90° azimuth, set the lower threshold to 0 and the upper threshold to 90. See the example configuration file for a basic set-up (north, east, south, west).
 

--- a/base/accessory.js
+++ b/base/accessory.js
@@ -146,10 +146,9 @@ class SunlightAccessory {
   // - - - - - - - - Open Weather functions - - - - - - - -
   getWeather() {
     const { platformConfig, log } = this;
-    const { lat, long, apikey } = platformConfig;
+    const { lat, long, apikey, weatherUpdateIntervalSeconds } = platformConfig;
 
-    // Only fetch new data once per minute
-    if (!this.cachedWeatherObj || this.lastupdate + 60 < (new Date().getTime() / 1000 | 0)) {
+    if (!this.cachedWeatherObj || (this.lastupdate + weatherUpdateIntervalSeconds) < (new Date().getTime() / 1000 | 0)) {
       let p = new Promise((resolve, reject) => {
         var url = 'http://api.openweathermap.org/data/2.5/weather?appid=' + apikey + '&lat=' + lat + '&lon=' + long;
         if (platformConfig.debugLog) log("Checking weather: %s", url);

--- a/base/accessory.js
+++ b/base/accessory.js
@@ -1,7 +1,7 @@
 const suncalc = require('suncalc');
 const request = require('request');
 
-class SunlightAccessory {
+class SunAzimuthAccessory {
   constructor(log, config, platformConfig) {
     this.accessory = null;
     this.registered = null;
@@ -37,7 +37,7 @@ class SunlightAccessory {
     const accessory = new Accessory(config.name, uuid);
     // Add Device Information
     accessory.getService(Service.AccessoryInformation)
-      .setCharacteristic(Characteristic.Manufacturer, 'Krillle')
+      .setCharacteristic(Characteristic.Manufacturer, 'mfkrause, Krillle & awaescher')
       .setCharacteristic(Characteristic.Model, 'Azimuth ' + lowerThreshold + '-' + upperThreshold)
       .setCharacteristic(Characteristic.SerialNumber, '---');
 
@@ -173,4 +173,4 @@ class SunlightAccessory {
   };
 }
 
-module.exports = SunlightAccessory;
+module.exports = SunAzimuthAccessory;

--- a/base/accessory.js
+++ b/base/accessory.js
@@ -80,7 +80,7 @@ class SunlightAccessory {
 
   updateState() {
     const { config, platformConfig, log } = this;
-    const { lat, long, apikey, maxCloudCoverage } = platformConfig;
+    const { lat, long, apikey, highestAcceptableOvercast } = platformConfig;
     const { lowerThreshold, upperThreshold } = config;
     const threshold = [lowerThreshold, upperThreshold];
 
@@ -126,9 +126,9 @@ class SunlightAccessory {
     // Sun is in relevant azimuth range, lets check daylight and clouds
     if (newState && apikey) {
       let sunState = this.returnSunFromCache();
-      let cloudCoverage = this.returnCloudinessFromCache();
+      let overcast = this.returnOvercastFromCache();
       if (platformConfig.debugLog) log(`Sun state: ${sunState}%, Cloud state: ${cloudState}%`);
-      newState = sunState > 10 && sunState < 90 && cloudCoverage <= maxCloudCoverage;
+      newState = sunState > 10 && sunState < 90 && overcast <= highestAcceptableOvercast;
     }
 
     return newState;
@@ -174,7 +174,7 @@ class SunlightAccessory {
     }
   };
 
-  returnCloudinessFromCache() {
+  returnOvercastFromCache() {
     var value;
     if (this.cachedWeatherObj && this.cachedWeatherObj["clouds"]) {
         value = parseFloat(this.cachedWeatherObj["clouds"]["all"]);

--- a/base/accessory.js
+++ b/base/accessory.js
@@ -80,7 +80,7 @@ class SunlightAccessory {
 
   updateState() {
     const { config, platformConfig, log } = this;
-    const { lat, long, apikey } = platformConfig;
+    const { lat, long, apikey, maxCloudCoverage } = platformConfig;
     const { lowerThreshold, upperThreshold } = config;
     const threshold = [lowerThreshold, upperThreshold];
 
@@ -126,9 +126,9 @@ class SunlightAccessory {
     // Sun is in relevant azimuth range, lets check daylight and clouds
     if (newState && apikey) {
       let sunState = this.returnSunFromCache();
-      let cloudState = this.returnCloudinessFromCache();
+      let cloudCoverage = this.returnCloudinessFromCache();
       if (platformConfig.debugLog) log(`Sun state: ${sunState}%, Cloud state: ${cloudState}%`);
-      newState = sunState > 10 && sunState <90 && cloudState <= 25;
+      newState = sunState > 10 && sunState < 90 && cloudCoverage <= maxCloudCoverage;
     }
 
     return newState;

--- a/base/platform.js
+++ b/base/platform.js
@@ -1,8 +1,8 @@
-const SunlightAccessory = require('./accessory');
+const SunAzimuthAccessory = require('./accessory');
 
 let homebridge;
 
-class SunlightPlatform {
+class SunAzimuthPlatform {
   constructor(log, config) {
     this.config = config;
     this.log = log;
@@ -11,7 +11,7 @@ class SunlightPlatform {
     // Initialize accessories
     this.sensors = {};
     config.sensors.forEach((sensorConfig) => {
-      this.sensors[sensorConfig.name] = new SunlightAccessory(log, sensorConfig, config);
+      this.sensors[sensorConfig.name] = new SunAzimuthAccessory(log, sensorConfig, config);
     });
 
     // Register new accessories after homebridge loaded
@@ -31,7 +31,7 @@ class SunlightPlatform {
       if (!configExists) {
         log('Removing existing platform accessory from cache:', accessory.displayName);
         try {
-          homebridge.unregisterPlatformAccessories('homebridge-sunlight', 'Sunlight', [accessory]);
+          homebridge.unregisterPlatformAccessories('homebridge-sun-azimuth', 'Sun Azimuth', [accessory]);
         } catch (e) {
           log('Could not unregister platform accessory!', e);
         }
@@ -60,7 +60,7 @@ class SunlightPlatform {
           || sensorConfig.upperThreshold < -360) {
           log(`Error: Thresholds of sensor ${sensorConfig.name} are not correctly configured. Please refer to the README. Unregistering this cached accessory.`);
           try {
-            homebridge.unregisterPlatformAccessories('homebridge-sunlight', 'Sunlight', [accessory]);
+            homebridge.unregisterPlatformAccessories('homebridge-sun-azimuth', 'Sun Azimuth', [accessory]);
           } catch (e) {
             log('Could not unregister platform accessory!', e);
           }
@@ -72,7 +72,7 @@ class SunlightPlatform {
 
         // this.accessories[index] = this.sensors[accessory.displayName].initializeAccessory();
       });
-      homebridge.updatePlatformAccessories('homebridge-sunlight', 'Sunlight', this.accessories);
+      homebridge.updatePlatformAccessories('homebridge-sun-azimuth', 'Sun Azimuth', this.accessories);
     }
     const configuredAccessories = tempAccessories;
     this.accessories = [];
@@ -107,7 +107,7 @@ class SunlightPlatform {
 
     // Collect all accessories after initialization to register them with homebridge
     if (this.accessories.length > 0) {
-      homebridge.registerPlatformAccessories('homebridge-sunlight', 'Sunlight', this.accessories);
+      homebridge.registerPlatformAccessories('homebridge-sun-azimuth', 'Sun Azimuth', this.accessories);
     }
   }
 
@@ -120,8 +120,8 @@ class SunlightPlatform {
  * Set homebridge reference for platform, called from /index.js
  * @param {object} homebridgeRef The homebridge reference to use in the platform
  */
-SunlightPlatform.setHomebridge = (homebridgeRef) => {
+SunAzimuthPlatform.setHomebridge = (homebridgeRef) => {
   homebridge = homebridgeRef;
 };
 
-module.exports = SunlightPlatform;
+module.exports = SunAzimuthPlatform;

--- a/config-sample.json
+++ b/config-sample.json
@@ -1,5 +1,5 @@
 {
-    "platform": "Sunlight",
+    "platform": "Sun Azimuth",
     "lat": 50.110924,
     "long": 8.682127,
     "apikey": "OpenWeather API Key",

--- a/config.schema.json
+++ b/config.schema.json
@@ -23,6 +23,15 @@
                 "description": "If API key is provided, sunhsine is reported only during daylight times when sky is not overcast",
                 "required": false
             },
+            "maxCloudCoverage": {
+                "type": "number",
+                "title": "Cloud coverage threshold in percent",
+                "description": "Cloud coverage threshold in percent (100% is cloudy, 0% is sunny), below which the sensor should be activated. Only available if an OpenWeather API key is defined.",
+                "required": true,
+                "default": 25,
+                "minimum": 0,
+                "maximum": 100
+            },
             "sensors": {
                 "type": "array",
                 "title": "Sensors",

--- a/config.schema.json
+++ b/config.schema.json
@@ -23,10 +23,10 @@
                 "description": "If API key is provided, sunhsine is reported only during daylight times when sky is not overcast",
                 "required": false
             },
-            "maxCloudCoverage": {
+            "highestAcceptableOvercast": {
                 "type": "number",
-                "title": "Cloud coverage threshold in percent",
-                "description": "Cloud coverage threshold in percent (100% is cloudy, 0% is sunny), below which the sensor should be activated. Only available if an OpenWeather API key is defined.",
+                "title": "Highest acceptable overcast (in percent)",
+                "description": "Overcast threshold in percent, below which the sensor should be activated. 0% is sunny, 25% is slightly cloudy and 100% is cloudy. Only available if an OpenWeather API key is defined.",
                 "required": true,
                 "default": 25,
                 "minimum": 0,

--- a/config.schema.json
+++ b/config.schema.json
@@ -32,6 +32,15 @@
                 "minimum": 0,
                 "maximum": 100
             },
+            "weatherUpdateIntervalSeconds": {
+                "type": "number",
+                "title": "Weather update interval in seconds",
+                "description": "The smaller the interval, the quicker the response to sun position and overcast updates but the more traffic you'll create. The free tier of the OpenWeather API is limited to 1,000,000 requests per month which is roughly one call every 3 seconds for a whole month.",
+                "required": true,
+                "default": 60,
+                "minimum": 3,
+                "maximum": 7200
+            },
             "sensors": {
                 "type": "array",
                 "title": "Sensors",

--- a/config.schema.json
+++ b/config.schema.json
@@ -35,7 +35,7 @@
             "weatherUpdateIntervalSeconds": {
                 "type": "number",
                 "title": "Weather update interval in seconds",
-                "description": "The smaller the interval, the quicker the response to sun position and overcast updates but the more traffic you'll create. The free tier of the OpenWeather API is limited to 1,000,000 requests per month which is roughly one call every 3 seconds for a whole month.",
+                "description": "The smaller the interval, the quicker the response to sun position and overcast updates but the more traffic it'll create. The free tier of the OpenWeather API is limited to 1,000,000 requests per month which is roughly one call every 3 seconds for a whole month.",
                 "required": true,
                 "default": 60,
                 "minimum": 3,
@@ -69,6 +69,24 @@
                             "title": "Upper Threshold",
                             "description": "Right side of sky section within which the sensor should activate",
                             "required": true
+                        },
+                        "lowerAltitudeThreshold": {
+                            "type": "number",
+                            "title": "Lower Altitude Threshold",
+                            "description": "Lower altitude threshold for the sun's position above the horizon, above which the sensor should activate. The threshold is measured in degrees, with 0° being on the horizon and 90° being at the zenith.",
+                            "required": true,
+                            "default": 0,
+                            "minimum": 0,
+                            "maximum": 90
+                        },
+                        "upperAltitudeThreshold": {
+                            "type": "number",
+                            "title": "Upper Altitude Threshold",
+                            "description": "Upper altitude threshold for the sun's position above the horizon, below which the sensor should activate. The threshold is measured in degrees, with 0° being on the horizon and 90° being at the zenith.",
+                            "required": true,
+                            "default": 90,
+                            "minimum": 0,
+                            "maximum": 90
                         }
                     }
                 }

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,9 +1,9 @@
 {
-    "pluginAlias": "Sunlight",
+    "pluginAlias": "Sun Azimuth",
     "pluginType": "platform",
     "singular": true,
     "headerDisplay": "This plugin provides contact sensors to automate sun protection. Sensors are opened (breached) when the sun is in a given section of the sky (azimuth) and optionally if an [OpenWeather API key](https://openweathermap.org/api) is provided when the sun is above the horizon and the sky is not overcast.",
-    "footerDisplay": "For help or in case of issues please visit the [GitHub repository](https://github.com/Krillle/homebridge-sunlight/issues). Based on [homebridge-sunsensors](https://github.com/mfkrause/homebridge-sunsensors).",
+    "footerDisplay": "For help or in case of issues please visit the [GitHub repository](https://github.com/awaescher/homebridge-sun-azimuth/issues). Based on [homebridge-sunsensors](https://github.com/mfkrause/homebridge-sunsensors) and [homebridge-sunlight](https://github.com/Krillle/homebridge-sunlight).",
     "schema": {
         "type": "object",
         "properties": {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const SunlightPlatform = require('./base/platform');
+const SunAzimuthPlatform = require('./base/platform');
 
 /* Register platform, set global variables */
 module.exports = (homebridge) => {
@@ -7,7 +7,7 @@ module.exports = (homebridge) => {
   global.UUIDGen = homebridge.hap.uuid;
   global.Accessory = homebridge.platformAccessory;
 
-  SunlightPlatform.setHomebridge(homebridge);
+  SunAzimuthPlatform.setHomebridge(homebridge);
 
-  homebridge.registerPlatform('homebridge-sunlight', 'Sunlight', SunlightPlatform);
+  homebridge.registerPlatform('homebridge-sun-azimuth', 'Sun Azimuth', SunAzimuthPlatform);
 };

--- a/package.json
+++ b/package.json
@@ -1,13 +1,17 @@
 {
-  "name": "homebridge-sunlight",
-  "displayName": "Sunlight",
-  "version": "0.2.3",
+  "name": "homebridge-sun-azimuth",
+  "displayName": "Sun Azimuth",
+  "version": "0.3.0",
   "description": "Homebridge plugin for contact sensors monitoring sun position, daylight and cloudiness",
-  "author": "Christian Wegerhoff <christian.wegerhoff@icloud.com>",
+  "author": "awaescher",
   "contributors": [
     {
       "name": "Maximilian Krause",
       "email": "hello@max-krause.com"
+    },
+    {
+      "name": "Christian Wegerhoff",
+      "email": "christian.wegerhoff@icloud.com"
     }
   ],
   "engines": {
@@ -18,15 +22,17 @@
     "homebridge-plugin",
     "sunlight",
     "sun",
+    "azimuth",
+    "sun azimuth",
     "sun protection",
     "window covering"
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/Krillle/homebridge-sunlight.git"
+    "url": "git://github.com/awaescher/homebridge-sun-azimuth.git"
   },
   "bugs": {
-    "url": "https://github.com/Krillle/homebridge-sunlight/issues"
+    "url": "https://github.com/awaescher/homebridge-sun-azimuth/issues"
   },
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
## Please merge #2 first.

This pull request adds ....
 - **Lower Altitude Threshold**
   _Lower altitude threshold for the sun's position above the horizon, above which the sensor should activate. The threshold is measured in degrees, with 0° being on the horizon and 90° being at the zenith._
 -  **Upper Altitude Threshold**
   _Upper altitude threshold for the sun's position above the horizon, below which the sensor should activate. The threshold is measured in degrees, with 0° being on the horizon and 90° being at the zenith._

... for each sensor.

Much of the code was taken from the closed pull request #1.